### PR TITLE
Fix type declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,6 @@ import { EnzymeAdapter } from 'enzyme';
 
 declare module "@wojtekmaj/enzyme-adapter-react-17" {
   export default class ReactSeventeenAdapter extends EnzymeAdapter {
-    constructor () {};
+    constructor();
   }
 }


### PR DESCRIPTION
TSC emits the following errors for index.d.ts:

```
node_modules/@wojtekmaj/enzyme-adapter-react-17/index.d.ts:5:5 - error TS2377: Constructors for derived classes must contain a 'super' call.

5     constructor () {};
      ~~~~~~~~~~~~~~~~~

node_modules/@wojtekmaj/enzyme-adapter-react-17/index.d.ts:5:20 - error TS1183: An implementation cannot be declared in ambient contexts.

5     constructor () {};
                     ~
```


This PR fixes the issues by removing the implementation from the constructor in this type declaration.