### PR TITLE
chore: add missing index.d.ts in package's files

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "LICENSE",
     "README.md",
     "build/",
-    "src/"
+    "src/",
+    "index.d.ts"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Since `v0.4.0` released today, the `index.d.ts` isn't anymore in the published package, so it's not usable in TypeScript environment without manually adding types for this dep.

![image](https://user-images.githubusercontent.com/4543679/102537704-96e35c00-40ab-11eb-8c46-b71c5a599099.png)
