### PR TITLE
Fix typings to allow import from TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,10 @@
 import { EnzymeAdapter } from 'enzyme';
 
-declare module "@wojtekmaj/enzyme-adapter-react-17" {
-  export default class ReactSeventeenAdapter extends EnzymeAdapter {
-    constructor();
-  }
+declare class ReactSeventeenAdapter extends EnzymeAdapter {
 }
+
+declare namespace ReactSeventeenAdapter {
+}
+
+export = ReactSeventeenAdapter;
+


### PR DESCRIPTION
Changed typings so it is similar to https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/enzyme-adapter-react-16/index.d.ts to allow import from TypeScript.

Fixes #10 