### PR TITLE
Ensure recursive calls to `displayNameOfNode` uses the adapter's version of the method

### DIFF
--- a/src/ReactSeventeenAdapter.js
+++ b/src/ReactSeventeenAdapter.js
@@ -810,6 +810,7 @@ class ReactSeventeenAdapter extends EnzymeAdapter {
   displayNameOfNode(node) {
     if (!node) return null;
     const { type, $$typeof } = node;
+    const adapter = this;
 
     const nodeType = type || $$typeof;
 
@@ -833,13 +834,13 @@ class ReactSeventeenAdapter extends EnzymeAdapter {
       case ContextProvider || NaN: return 'ContextProvider';
       case Memo || NaN: {
         const nodeName = displayNameOfNode(node);
-        return typeof nodeName === 'string' ? nodeName : `Memo(${displayNameOfNode(type)})`;
+        return typeof nodeName === 'string' ? nodeName : `Memo(${adapter.displayNameOfNode(type)})`;
       }
       case ForwardRef || NaN: {
         if (type.displayName) {
           return type.displayName;
         }
-        const name = displayNameOfNode({ type: type.render });
+        const name = adapter.displayNameOfNode({ type: type.render });
         return name ? `ForwardRef(${name})` : 'ForwardRef';
       }
       case Lazy || NaN: {


### PR DESCRIPTION
Fixes #14 

Ported changes done in https://github.com/enzymejs/enzyme/commit/75e89636e2f8b908c1151d37857d45b956ce5698

First contribution to this project, let me know if any changes are needed to resolve this issue.