### PR TITLE
Fix console.error when NODE_ENV is production

### DIFF
--- a/src/ReactSeventeenAdapter.js
+++ b/src/ReactSeventeenAdapter.js
@@ -357,7 +357,11 @@ function getEmptyStateValue() {
 
 function wrapAct(fn) {
   let returnVal;
-  TestUtils.act(() => { returnVal = fn(); });
+  if (process.env.NODE_ENV === 'production') {
+    returnVal = fn();
+  } else {
+    TestUtils.act(() => { returnVal = fn(); });
+  }
   return returnVal;
 }
 


### PR DESCRIPTION
Fix `act(...) is not supported in production builds of React, and might not behave as expected.` console error when `NODE_ENV` is `production`. Test pass after all but jest prints the error.

![test](https://user-images.githubusercontent.com/367128/114791815-6e345000-9d87-11eb-894e-56d61a3c8dbb.png)
