### PR TITLE
Filter out null values from node arrays

### DIFF
--- a/src/ReactSeventeenAdapter.js
+++ b/src/ReactSeventeenAdapter.js
@@ -799,7 +799,8 @@ class ReactSeventeenAdapter extends EnzymeAdapter {
   nodeToHostNode(node, supportsArray = false) {
     const nodes = nodeToHostNode(node);
     if (Array.isArray(nodes) && !supportsArray) {
-      return nodes[0];
+      // get the first non-null node
+      return nodes.filter(Boolean)[0];
     }
     return nodes;
   }

--- a/test/test/shared/methods/simulate.jsx
+++ b/test/test/shared/methods/simulate.jsx
@@ -320,5 +320,22 @@ export default function describeSimulate({ Wrap, WrapperName, isShallow, isMount
         expect(effectSpy).to.have.property('callCount', 2);
       });
     });
+
+    it('works with components that return null children', () => {
+      class NullChildren extends React.Component {
+        render() {
+          return (
+            <>
+              <></>
+              <button type="button" />
+            </>
+          );
+        }
+      }
+
+      const wrapper = Wrap(<NullChildren />);
+
+      wrapper.simulate('click');
+    });
   });
 }


### PR DESCRIPTION
Fixes https://github.com/wojtekmaj/enzyme-adapter-react-17/issues/42

This filters out null values from node arrays in the adapter. The problem is that some React component trees render as an array with possible null values when using React fragments, e.g.

```
<>
  <EmptyFragmentComponent />
  <ConditionallyNullComponent />
  <SomeComponent />
</>
```

where `EmptyFragmentComponent` renders an empty fragment (it exists to run `useEffect` hooks, for instance) and `ConditionallyNullComponent` may render a `null` value explicitly based on the state of the application (e.g. if not authenticated, don't show a banner). `SomeComponent` renders a `div` and so is not null in the `nodes` array.

In the resulting `nodes` value from `nodeToHostNode`, the output is `[null, null, Object]`, which causes `nodes[0]` to return `null` and give the error `TypeError: Cannot read property '__reactFiber$ul8w880oi5m' of null` during testing.